### PR TITLE
Make Package work with RN version > 0.47

### DIFF
--- a/android/src/main/java/com/languagedrops/rnsvg/SvgImagePackage.java
+++ b/android/src/main/java/com/languagedrops/rnsvg/SvgImagePackage.java
@@ -21,7 +21,6 @@ public class SvgImagePackage implements ReactPackage {
       return Collections.emptyList();
     }
 
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Arrays.<ViewManager>asList(
           new SvgImageManager()


### PR DESCRIPTION
supposed to be backward compatible

Edit: I was wrong. This doesn't work, because we shouldn't use `createViewManagers` function but we are using it for creating `SvgImageManager`.